### PR TITLE
Solve unpacking error

### DIFF
--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -108,10 +108,11 @@ def _train(client, params, data, labels, **kwargs):
 
     # Because XGBoost-python doesn't yet allow iterative training, we need to
     # find the locations of all chunks and map them to particular Dask workers
+    key_to_part_dict = dict([(part.key, part) for part in parts])
     who_has = yield client.scheduler.who_has(keys=[part.key for part in parts])
     worker_map = defaultdict(list)
     for key, workers in who_has.items():
-        worker_map[first(workers)].append(key)
+        worker_map[first(workers)].append(key_to_part_dict[key])
 
     ncores = yield client.scheduler.ncores()  # Number of cores per worker
 


### PR DESCRIPTION
I've been trying to run through something similar to the blogpost [here](http://matthewrocklin.com/blog/work/2017/03/28/dask-xgboost), but I was running into errors that looked like this:

```
File "/Users/proth/.conda/envs/dask/lib/python3.5/site-packages/dask_xgboost-0.1.3-py3.5.egg/dask_xgboost/core.py", line 68, in train_part
    data, labels = zip(*list_of_parts)  # Prepare data
ValueError: too many values to unpack (expected 2)
```

I believe this PR solves that issue. Perhaps the underlying dask API has changed since this was written? I haven't tested this change on dask arrays.