### PR TITLE
fix nthread param typo

### DIFF
--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -125,7 +125,7 @@ def _train(client, params, data, labels, dmatrix_kwargs={}, **kwargs):
 
     # Tell each worker to train on the chunks/parts that it has locally
     futures = [client.submit(train_part, env,
-                             assoc(params, 'nthreads', ncores[worker]),
+                             assoc(params, 'nthread', ncores[worker]),
                              list_of_parts, workers=worker,
                              dmatrix_kwargs=dmatrix_kwargs, **kwargs)
                for worker, list_of_parts in worker_map.items()]


### PR DESCRIPTION
I was having issues with distributed training where I was seeing a race condition develop. As soon as I manually implemented nthread=<available threads> i realized that `core.py` improperly sets this parameter as `nthreads` and therefore xgboost ignores it and goes to the default behavior.