### PR TITLE
Add evals result

### DIFF
--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -100,8 +100,6 @@ def train_part(
         n_jobs=n_jobs,
     )
 
-    evals_result = {}
-
     args = [("%s=%s" % item).encode() for item in env.items()]
     xgb.rabit.init(args)
     try:
@@ -208,11 +206,11 @@ def _train(client, params, data, labels, dmatrix_kwargs={}, **kwargs):
 
     # Get the results, only one will be non-None
     results = yield client._gather(futures)
-    result = [v for v in results if v][0]
+    result, evals_result = [v for v in results if v][0]
     num_class = params.get("num_class")
     if num_class:
         result.set_attr(num_class=str(num_class))
-    raise gen.Return(result)
+    raise gen.Return((result, evals_result))
 
 
 def train(client, params, data, labels, dmatrix_kwargs={}, **kwargs):

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -124,11 +124,6 @@ def _package_evals(
     eval_set, sample_weight_eval_set=None, missing=None, n_jobs=None
 ):
     if eval_set is not None:
-        if any(is_dask_collection(e) for evals in eval_set for e in evals):
-            raise TypeError(
-                "Evaluation set must not contain dask collections."
-            )
-
         if sample_weight_eval_set is None:
             sample_weight_eval_set = [None] * len(eval_set)
         evals = list(
@@ -186,6 +181,16 @@ def _train(
     for part in parts:
         if part.status == "error":
             yield part  # trigger error locally
+
+    if kwargs.get("eval_set"):
+        if any(
+            is_dask_collection(e)
+            for evals in kwargs.get("eval_set")
+            for e in evals
+        ):
+            raise TypeError(
+                "Evaluation set must not contain dask collections."
+            )
 
     # Because XGBoost-python doesn't yet allow iterative training, we need to
     # find the locations of all chunks and map them to particular Dask workers

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -243,6 +243,8 @@ def train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, **
     data: dask array or dask.dataframe
     labels: dask.array or dask.dataframe
     dmatrix_kwargs: Keywords to give to Xgboost DMatrix
+    evals_result: dict
+        Stores the evaluation result history of all the items in the eval_set.
     **kwargs: Keywords to give to XGBoost train
 
     Examples

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -206,7 +206,7 @@ def _train(client, params, data, labels, dmatrix_kwargs={}, **kwargs):
 
     # Get the results, only one will be non-None
     results = yield client._gather(futures)
-    result, evals_result = [v for v in results if v][0]
+    result, evals_result = [v for v in results if v.count(None) != len(v)][0]
     num_class = params.get("num_class")
     if num_class:
         result.set_attr(num_class=str(num_class))

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -254,7 +254,7 @@ def train(
     data: dask array or dask.dataframe
     labels: dask.array or dask.dataframe
     dmatrix_kwargs: Keywords to give to Xgboost DMatrix
-    evals_result: dict
+    evals_result: dict, optional
         Stores the evaluation result history of all the items in the eval_set
         by mutating evals_result in place.
     **kwargs: Keywords to give to XGBoost train

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -124,6 +124,18 @@ def _package_evals(
     eval_set, sample_weight_eval_set=None, missing=None, n_jobs=None
 ):
     if eval_set is not None:
+        eval_set_dask_collections = [
+            type(e)
+            for evals in eval_set
+            for e in evals
+            if isinstance(e, (da.Array, dd.DataFrame, dd.Series))
+        ]
+        if len(eval_set_dask_collections) > 0:
+            raise TypeError(
+                "Evaluation set must not contain dask collection"
+                ". Got %s" % eval_set_dask_collections
+            )
+
         if sample_weight_eval_set is None:
             sample_weight_eval_set = [None] * len(eval_set)
         evals = list(

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -159,7 +159,15 @@ def _package_evals(
 
 
 @gen.coroutine
-def _train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, **kwargs):
+def _train(
+    client,
+    params,
+    data,
+    labels,
+    dmatrix_kwargs={},
+    evals_result=None,
+    **kwargs
+):
     """
     Asynchronous version of train
 
@@ -189,7 +197,9 @@ def _train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, *
     # Because XGBoost-python doesn't yet allow iterative training, we need to
     # find the locations of all chunks and map them to particular Dask workers
     key_to_part_dict = dict([(part.key, part) for part in parts])
-    who_has = yield client.scheduler.who_has(keys=[part.key for part in parts])
+    who_has = yield client.scheduler.who_has(
+        keys=[part.key for part in parts]
+    )
     worker_map = defaultdict(list)
     for key, workers in who_has.items():
         worker_map[first(workers)].append(key_to_part_dict[key])
@@ -229,7 +239,15 @@ def _train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, *
     raise gen.Return(result)
 
 
-def train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, **kwargs):
+def train(
+    client,
+    params,
+    data,
+    labels,
+    dmatrix_kwargs={},
+    evals_result=None,
+    **kwargs
+):
     """ Train an XGBoost model on a Dask Cluster
 
     This starts XGBoost on all Dask workers, moves input data to those workers,
@@ -261,7 +279,14 @@ def train(client, params, data, labels, dmatrix_kwargs={}, evals_result=None, **
     predict
     """
     return client.sync(
-        _train, client, params, data, labels, dmatrix_kwargs, evals_result, **kwargs
+        _train,
+        client,
+        params,
+        data,
+        labels,
+        dmatrix_kwargs,
+        evals_result,
+        **kwargs
     )
 
 

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -552,7 +552,6 @@ class XGBClassifier(xgb.XGBClassifier):
             self.best_score = self._Booster.best_score
             self.best_iteration = self._Booster.best_iteration
             self.best_ntree_limit = self._Booster.best_ntree_limit
-
         return self
 
     def predict(self, X):

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -399,7 +399,7 @@ def test_regressor_evals_result(loop):  # noqa
             a = dxgb.XGBRegressor()
             X2 = da.from_array(X, 5)
             y2 = da.from_array(y, 5)
-            a.fit(X2, y2, eval_metric="rmse", eval_set=[(X2, y2)])
+            a.fit(X2, y2, eval_metric="rmse", eval_set=[(X, y)])
             evals_result = a.evals_result()
 
     b = xgb.XGBRegressor()
@@ -412,7 +412,7 @@ def test_classifier_evals_result(loop):  # noqa
             a = dxgb.XGBClassifier()
             X2 = da.from_array(X, 5)
             y2 = da.from_array(y, 5)
-            a.fit(X2, y2, eval_metric="rmse", eval_set=[(X2, y2)])
+            a.fit(X2, y2, eval_metric="rmse", eval_set=[(X, y)])
             evals_result = a.evals_result()
 
     b = xgb.XGBClassifier()

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -159,6 +159,13 @@ def test_package_evals():
 
     assert len(evals) == 1
 
+    X2 = da.from_array(X_test, 5)
+    y2 = da.from_array(y_test, 5)
+
+    with pytest.raises(TypeError) as info:
+        _package_evals(eval_set=[(X2, y2)])
+
+    assert "Evaluation set must not contain dask collections." in str(info.value)
 
 @pytest.mark.parametrize("kind", ["array", "dataframe"])
 def test_classifier_multi(kind, loop):  # noqa: F811
@@ -426,18 +433,3 @@ def test_classifier_evals_result(loop):  # noqa
     b = xgb.XGBClassifier()
     b.fit(X, y, eval_metric="rmse", eval_set=[(X, y)])
     assert_eq(evals_result, b.evals_result())
-
-
-def test_eval_set_dask_collection_exception(loop):  # noqa
-    with cluster() as (s, [a, b]):
-        with Client(s["address"], loop=loop):
-            a = dxgb.XGBClassifier()
-            X2 = da.from_array(X, 5)
-            y2 = da.from_array(y, 5)
-
-            with pytest.raises(TypeError) as info:
-                a.fit(X2, y2, eval_metric="rmse", eval_set=[(X2, y2)])
-
-            assert "Evaluation set must not contain dask collections." in str(
-                info.value
-            )

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -24,11 +24,19 @@ distributed.comm.utils._offload_executor = ThreadPoolExecutor(max_workers=2)
 
 
 df = pd.DataFrame(
-    {"x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "y": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]}
+    {
+        "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "y": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+    }
 )
 labels = pd.Series([1, 0, 1, 0, 1, 0, 1, 1, 1, 1])
 
-param = {"max_depth": 2, "eta": 1, "silent": 1, "objective": "binary:logistic"}
+param = {
+    "max_depth": 2,
+    "eta": 1,
+    "silent": 1,
+    "objective": "binary:logistic",
+}
 
 X = df.values
 y = labels.values
@@ -135,22 +143,18 @@ def test_package_evals():
     y = digits["target"]
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
+    evals = _package_evals([(X_test, y_test), (X, y_test)])
+
+    assert len(evals) == 2
+
     evals = _package_evals(
-        [(X_test, y_test), (X, y_test)],
+        [(X_test, y_test), (X, y_test)], sample_weight_eval_set=[[1], [2]]
     )
 
     assert len(evals) == 2
 
     evals = _package_evals(
-        [(X_test, y_test), (X, y_test)],
-        sample_weight_eval_set=[[1], [2]],
-    )
-
-    assert len(evals) == 2
-
-    evals = _package_evals(
-        [(X_test, y_test), (X, y_test)],
-        sample_weight_eval_set=[[1]],
+        [(X_test, y_test), (X, y_test)], sample_weight_eval_set=[[1]]
     )
 
     assert len(evals) == 1
@@ -221,7 +225,9 @@ def test_regressor_with_early_stopping(loop):  # noqa
             p1 = a.predict(X2)
 
     b = xgb.XGBRegressor()
-    b.fit(X, y, early_stopping_rounds=4, eval_metric="rmse", eval_set=[(X, y)])
+    b.fit(
+        X, y, early_stopping_rounds=4, eval_metric="rmse", eval_set=[(X, y)]
+    )
     assert_eq(p1, b.predict(X))
     assert_eq(a.best_score, b.best_score)
 
@@ -381,7 +387,7 @@ async def test_predict_proba(c, s, a, b):
     np.testing.assert_array_equal(result, expected)
 
     # dataframe
-    XX = dd.from_dask_array(X, columns=['A', 'B'])
+    XX = dd.from_dask_array(X, columns=["A", "B"])
     yy = dd.from_dask_array(y)
     XX_ = await c.compute(XX)
 

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -136,7 +136,7 @@ def test_package_evals():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
     evals = _package_evals(
-        [(X_test, y_test), (X, y_test)]
+        [(X_test, y_test), (X, y_test)],
     )
 
     assert len(evals) == 2

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -136,7 +136,7 @@ def test_package_evals():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
     evals = _package_evals(
-        [(X_test, y_test), (X, y_test)],
+        [(X_test, y_test), (X, y_test)]
     )
 
     assert len(evals) == 2
@@ -233,8 +233,8 @@ def test_basic(c, s, a, b):
 
     ddf = dd.from_pandas(df, npartitions=4)
     dlabels = dd.from_pandas(labels, npartitions=4)
-    dbst, evals_result = yield dxgb.train(c, param, ddf, dlabels)
-    dbst, evals_result = yield dxgb.train(c, param, ddf, dlabels)  # we can do this twice
+    dbst = yield dxgb.train(c, param, ddf, dlabels)
+    dbst = yield dxgb.train(c, param, ddf, dlabels)  # we can do this twice
 
     result = bst.predict(dtrain)
     dresult = dbst.predict(dtrain)
@@ -256,7 +256,7 @@ def test_dmatrix_kwargs(c, s, a, b):
     xgb.rabit.init()  # workaround for "Doing rabit call after Finalize"
     dX = da.from_array(X, chunks=(2, 2))
     dy = da.from_array(y, chunks=(2,))
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy, {"missing": 0.0})
+    dbst = yield dxgb.train(c, param, dX, dy, dmatrix_kwargs={"missing": 0.0})
 
     # Distributed model matches local model with dmatrix kwargs
     dtrain = xgb.DMatrix(X, label=y, missing=0.0)
@@ -291,8 +291,8 @@ def test_numpy(c, s, a, b):
     xgb.rabit.init()  # workaround for "Doing rabit call after Finalize"
     dX = da.from_array(X, chunks=(2, 2))
     dy = da.from_array(y, chunks=(2,))
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)  # we can do this twice
+    dbst = yield dxgb.train(c, param, dX, dy)
+    dbst = yield dxgb.train(c, param, dX, dy)  # we can do this twice
 
     predictions = dxgb.predict(c, dbst, dX)
     assert isinstance(predictions, da.Array)
@@ -305,8 +305,8 @@ def test_scipy_sparse(c, s, a, b):
     xgb.rabit.init()  # workaround for "Doing rabit call after Finalize"
     dX = da.from_array(X, chunks=(2, 2)).map_blocks(scipy.sparse.csr_matrix)
     dy = da.from_array(y, chunks=(2,))
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)  # we can do this twice
+    dbst = yield dxgb.train(c, param, dX, dy)
+    dbst = yield dxgb.train(c, param, dX, dy)  # we can do this twice
 
     predictions = dxgb.predict(c, dbst, dX)
     assert isinstance(predictions, da.Array)
@@ -320,8 +320,8 @@ def test_sparse(c, s, a, b):
     xgb.rabit.init()  # workaround for "Doing rabit call after Finalize"
     dX = da.from_array(X, chunks=(2, 2)).map_blocks(scipy.sparse.csr_matrix)
     dy = da.from_array(y, chunks=(2,))
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)
-    dbst, evals_result = yield dxgb.train(c, param, dX, dy)  # we can do this twice
+    dbst = yield dxgb.train(c, param, dX, dy)
+    dbst = yield dxgb.train(c, param, dX, dy)  # we can do this twice
 
     predictions = dxgb.predict(c, dbst, dX)
     assert isinstance(predictions, da.Array)
@@ -340,7 +340,7 @@ def test_synchronous_api(loop):  # noqa
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
 
-            dbst, evals_result = dxgb.train(c, param, ddf, dlabels)
+            dbst = dxgb.train(c, param, ddf, dlabels)
 
             result = bst.predict(dtrain)
             dresult = dbst.predict(dtrain)
@@ -393,6 +393,7 @@ async def test_predict_proba(c, s, a, b):
     expected = booster.predict(xgb.DMatrix(XX_))
     np.testing.assert_array_equal(result, expected)
 
+
 def test_regressor_evals_result(loop):  # noqa
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop):
@@ -405,6 +406,7 @@ def test_regressor_evals_result(loop):  # noqa
     b = xgb.XGBRegressor()
     b.fit(X, y, eval_metric="rmse", eval_set=[(X, y)])
     assert_eq(evals_result, b.evals_result())
+
 
 def test_classifier_evals_result(loop):  # noqa
     with cluster() as (s, [a, b]):

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -426,3 +426,18 @@ def test_classifier_evals_result(loop):  # noqa
     b = xgb.XGBClassifier()
     b.fit(X, y, eval_metric="rmse", eval_set=[(X, y)])
     assert_eq(evals_result, b.evals_result())
+
+
+def test_eval_set_dask_collection_exception(loop):  # noqa
+    with cluster() as (s, [a, b]):
+        with Client(s["address"], loop=loop):
+            a = dxgb.XGBClassifier()
+            X2 = da.from_array(X, 5)
+            y2 = da.from_array(y, 5)
+
+            with pytest.raises(TypeError) as info:
+                a.fit(X2, y2, eval_metric="rmse", eval_set=[(X2, y2)])
+
+            assert "Evaluation set must not contain dask collections." in str(
+                info.value
+            )


### PR DESCRIPTION
**What**

Closes https://github.com/dask/dask-xgboost/issues/59

Adds local_evals dictionary to each workers `xgb.train` method. When all workers return and are aggregated, the evals_result dict that is passed into the `dask-xgboost.train` method is updated with the resulting evaluation history.

**Why**

It is desirable to recall the evaluation at each iteration of the training process after training the model. This is a feature that exists in dmlc/xgboost that would be nice to have in dask-xgboost

**Test**

```
import dask
import dask.array as da
import numpy as np
import pandas as pd
from dask.distributed import Client, LocalCluster
from sklearn.datasets import load_digits, load_iris
from sklearn.model_selection import train_test_split

import dask_xgboost as dxgb
import xgboost as xgb

df = pd.DataFrame(
    {"x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "y": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0]}
)
labels = pd.Series([1, 0, 1, 0, 1, 0, 1, 1, 1, 1])

X = df.values
y = labels.values

X2 = da.from_array(X, 5)
y2 = da.from_array(y, 5)

cluster = LocalCluster()
c = Client(cluster)

a = dxgb.XGBRegressor(eval_metric="rmse", random_state=1, seed=1, verbosity=0)
a.fit(X2, y2, eval_set=[(X, y)])

b = xgb.XGBRegressor(eval_metric="rmse", random_state=1, seed=1, verbosity=0)
b.fit(X, y, eval_set=[(X, y)])

c = xgb.dask.DaskXGBRegressor(eval_metric='rmse', random_state=1, seed=1, verbosity=0)
c.fit(X2, y2, eval_set=[(X2, y2)])

assert a.evals_result() == b.evals_result()
assert a.evals_result() == c.evals_result()
assert b.evals_result() == c.evals_result()
```
```
>>> print(a.evals_result())
{'validation_0': {'rmse': [0.461261, 0.425567, 0.392674, 0.36236, 0.334421, 0.308667, 0.284927, 0.263039, 0.242859, 0.22425, 0.207089, 0.191262, 0.176663, 0.163196, 0.150772, 0.139231, 0.128591, 0.118781, 0.109739, 0.101406, 0.093727, 0.086653, 0.080138, 0.074139, 0.068618, 0.063538, 0.058867, 0.054574, 0.050631, 0.047013, 0.043661, 0.04055, 0.037662, 0.034981, 0.032493, 0.030182, 0.028037, 0.026046, 0.024197, 0.02248, 0.020885, 0.019405, 0.01803, 0.016754, 0.015568, 0.014467, 0.013444, 0.012494, 0.011612, 0.010792, 0.010031, 0.009323, 0.008666, 0.008056, 0.007489, 0.006962, 0.006472, 0.006017, 0.005595, 0.005202, 0.004837, 0.004498, 0.004182, 0.003889, 0.003621, 0.003367, 0.003132, 0.002913, 0.002709, 0.00252, 0.002344, 0.00218, 0.002033, 0.001892, 0.00176, 0.001637, 0.00153, 0.001428, 0.001336, 0.001243, 0.001164, 0.001083, 0.001017, 0.000956, 0.000891, 0.00084, 0.000794, 0.000752, 0.000715, 0.000708, 0.000702, 0.000697, 0.000664, 0.00066, 0.000657, 0.000654, 0.000652, 0.00065, 0.000649, 0.000648]}}
```

