### PR TITLE
change predict threshold from 0 to 0.5

### DIFF
--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -603,13 +603,13 @@ class XGBClassifier(xgb.XGBClassifier):
             self.best_ntree_limit = self._Booster.best_ntree_limit
         return self
 
-    def predict(self, X, threshold=0.5):
+    def predict(self, X):
         client = default_client()
         class_probs = predict(client, self._Booster, X)
         if class_probs.ndim > 1:
             cidx = da.argmax(class_probs, axis=1)
         else:
-            cidx = (class_probs >= threshold).astype(np.int64)
+            cidx = (class_probs >= 0.5).astype(np.int64)
         return cidx
 
     def predict_proba(self, data, ntree_limit=None):

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -609,7 +609,7 @@ class XGBClassifier(xgb.XGBClassifier):
         if class_probs.ndim > 1:
             cidx = da.argmax(class_probs, axis=1)
         else:
-            cidx = (class_probs >= 0.5).astype(np.int64)
+            cidx = (class_probs > 0.5).astype(np.int64)
         return cidx
 
     def predict_proba(self, data, ntree_limit=None):

--- a/dask_xgboost/core.py
+++ b/dask_xgboost/core.py
@@ -603,13 +603,13 @@ class XGBClassifier(xgb.XGBClassifier):
             self.best_ntree_limit = self._Booster.best_ntree_limit
         return self
 
-    def predict(self, X):
+    def predict(self, X, threshold=0.5):
         client = default_client()
         class_probs = predict(client, self._Booster, X)
         if class_probs.ndim > 1:
             cidx = da.argmax(class_probs, axis=1)
         else:
-            cidx = (class_probs > 0).astype(np.int64)
+            cidx = (class_probs >= threshold).astype(np.int64)
         return cidx
 
     def predict_proba(self, data, ntree_limit=None):

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -40,11 +40,15 @@ y = labels.values
 
 
 def test_classifier(loop):  # noqa
+    digits = load_digits(2)
+    X = digits["data"]
+    y = digits["target"]
+
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop):
             a = dxgb.XGBClassifier()
-            X2 = da.from_array(X, 5)
-            y2 = da.from_array(y, 5)
+            X2 = da.from_array(X)
+            y2 = da.from_array(y)
             a.fit(X2, y2)
             p1 = a.predict(X2)
 

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -557,18 +557,3 @@ def test_sample_weight_eval_set_dask_collection_exception(c, s, a, b):
     assert "Sample weight evaluation set must not contain dask collections." in str(
         info.value
     )
-
-def test_sigmoid_predict(loop):
-    y_1s = np.array([1]*len(y))
-    with cluster() as (s, [a, b]):
-        with Client(s["address"], loop=loop):
-            a, b = dxgb.XGBClassifier(), dxgb.XGBClassifier()
-            X2 = da.from_array(X, 5)
-            y2, y2_1s = da.from_array(y, 5), da.from_array(y_1s, 5)
-            a.fit(X2, y2)
-            b.fit(X2, y2_1s)
-            p1_prob, p1 = a.predict_proba(X2), a.predict(X2,0.7)
-            p2 = b.predict(X2) # Model should learn to predict all 1's
-
-    assert_eq(np.where(p1_prob>0.7,1,0), p1)
-    assert_eq(p2, y2_1s)

--- a/dask_xgboost/tests/test_core.py
+++ b/dask_xgboost/tests/test_core.py
@@ -557,3 +557,18 @@ def test_sample_weight_eval_set_dask_collection_exception(c, s, a, b):
     assert "Sample weight evaluation set must not contain dask collections." in str(
         info.value
     )
+
+def test_sigmoid_predict(loop):
+    y_1s = np.array([1]*len(y))
+    with cluster() as (s, [a, b]):
+        with Client(s["address"], loop=loop):
+            a, b = dxgb.XGBClassifier(), dxgb.XGBClassifier()
+            X2 = da.from_array(X, 5)
+            y2, y2_1s = da.from_array(y, 5), da.from_array(y_1s, 5)
+            a.fit(X2, y2)
+            b.fit(X2, y2_1s)
+            p1_prob, p1 = a.predict_proba(X2), a.predict(X2,0.7)
+            p2 = b.predict(X2) # Model should learn to predict all 1's
+
+    assert_eq(np.where(p1_prob>0.7,1,0), p1)
+    assert_eq(p2, y2_1s)


### PR DESCRIPTION
~Adds a threshold value to the predict function with a default of 0.5~

- Update predict threshold to `> 0.5` 
- Update `test_classifier` to use a more complex  dataset. Test fails on original threshold of `>0`, passes on change in this PR.

Related issue: https://github.com/dask/dask-xgboost/issues/62