### PR TITLE
Add link to xgb.dask API in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,18 +3,20 @@ Dask-XGBoost
 
 Distributed training with XGBoost and Dask.distributed
 
-This repository offers one option to perform distributed training with XGBoost on
-Dask.array and Dask.dataframe collections.
+This repository offers a legacy option to perform distributed training
+with XGBoost on Dask.array and Dask.dataframe collections.
 
 ::
 
    pip install dask-xgboost
 
-Please note that XGBoost also includes a Dask API as part of its official Python package.
-That API is independent of `dask-xgboost` and is the alternative recommended by the core XGBoost
-development team. See
+Please note that XGBoost now includes a Dask API as part of its official Python package.
+That API is independent of `dask-xgboost` and is now the recommended way to use Dask
+adn XGBoost together. See
 `the xgb.dask documentation here https://xgboost.readthedocs.io/en/latest/tutorials/dask.html`
-for more details on that option.
+for more details on the new API.
+
+
 
 Example
 -------

--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,18 @@ Dask-XGBoost
 
 Distributed training with XGBoost and Dask.distributed
 
-This repository enables you to perform distributed training with XGBoost on
+This repository offers one option to perform distributed training with XGBoost on
 Dask.array and Dask.dataframe collections.
 
 ::
 
    pip install dask-xgboost
+
+Please note that XGBoost also includes a Dask API as part of its official Python package.
+That API is independent of `dask-xgboost` and is the alternative recommended by the core XGBoost
+development team. See
+`the xgb.dask documentation here https://xgboost.readthedocs.io/en/latest/tutorials/dask.html`
+for more details on that option.
 
 Example
 -------


### PR DESCRIPTION
Aiming to start a discussion with this PR, per private syncs with @quasiben and @trivialfis. We've seen some confusion among users between `xgb.dask` (the Dask API built in to XGBoost) and `dask-xgboost` (which predates it and is developed more by the Dask org). XGBoost developers are fully committed to maintaining and improving Dask functionality - it's a high priority for the team. We'd love to make sure that new users who are looking for dask and xgboost options are aware that this alternative exists and is almost surely already installed if they have XGBoost installed.

Very open to tweaking the wording, of course.